### PR TITLE
Layout to show Header and Footer in web public

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,7 @@ import { AnimatedSwitch, spring } from 'react-router-transition';
 
 import { PageNotFound } from './Components/PageNotFound/PageNotFound';
 import Sidebar from './Components/Sidebar/Sidebar';
-import FooterPublic from './Components/Footer/FooterPublic';
+import Layout from './Components/Layout';
 
 function mapStyles (styles) {
   return {
@@ -58,8 +58,8 @@ function bounce (val) {
 function App () {
   return (
     <>
-        <BrowserRouter>
-
+      <BrowserRouter>
+        <Layout>
           <AnimatedSwitch
             atEnter={{ opacity: 0, translateX: -100 }}
             atActive={{ opacity: bounce(1), translateX: bounce(0) }}
@@ -89,8 +89,6 @@ function App () {
             <Route exact path="/backoffice/members/create" component={MembersForm} />
             <Route exact path="/create-project" component={ProjectsForm} />
             <Route exact path="/update-project/:id" component={ProjectsForm} />
-            <Route exact path="/school-campaign" component={SchoolCampaign} />
-            <Route exact path="/toys-campaign" component={ToysCampaign} />
             <Route exact path="/actividades/:id" component={ActivityDetail} />
             <Route exact path="/actividades" component={Activities} />
             <Route exact path="/register" component={RegisterForm} />
@@ -112,7 +110,10 @@ function App () {
 
             <Route path="/*" component={PageNotFound} />
           </AnimatedSwitch>
-        <FooterPublic />
+        </Layout>
+        {/* Estas dos rutas van fuera de Layout ya que usan un header y un footer diferentes */}
+        <Route exact path="/school-campaign" component={SchoolCampaign} />
+        <Route exact path="/toys-campaign" component={ToysCampaign} />
       </BrowserRouter>
       <div className="App">
         <header className="App-header"></header>

--- a/src/Components/Home/index.js
+++ b/src/Components/Home/index.js
@@ -13,7 +13,6 @@ import CarouselSlides from '../Slides/HomeSlide';
 import { get } from '../../Services/publicApiService';
 import Spinner from '../Spinner/index';
 import { showAlertErr } from '../../Services/AlertServicie/AlertServicie';
-import { FooterLandingPage } from '../Footer/FooterLandingPage';
 
 const Home = () => {
   const [loading, setLoading] = useState();
@@ -66,11 +65,11 @@ const Home = () => {
             templateRows="80px 2fr .5fr .5fr .5fr .5fr .5fr"
             templateColumns="1fr"
           >
-            <GridItem>
+            {/* <GridItem>
               <Text align={'center'} fontSize="4xl">
                 Navbar
               </Text>
-            </GridItem>
+            </GridItem> */}
             <CarouselSlides />
             <GridItem mb={6}>
               <Flex justify="center">
@@ -157,7 +156,6 @@ const Home = () => {
         : (
           <Spinner />
           )}
-      <FooterLandingPage />
     </>
   );
 };

--- a/src/Components/Layout/index.js
+++ b/src/Components/Layout/index.js
@@ -1,0 +1,19 @@
+import WithSubnavigation from '../Header';
+import FooterPublic from '../Footer/FooterPublic';
+import { useHistory } from 'react-router-dom';
+
+const Layout = ({ children }) => {
+  const history = useHistory();
+  return (
+    <>
+      {!history.location.pathname.includes('campaign') &&
+        <>
+          <WithSubnavigation />
+            {children}
+          <FooterPublic />
+        </>
+      }
+    </>
+  );
+};
+export default Layout;


### PR DESCRIPTION
### SUMMARY

- Created layout to render header and footer of the public web
- Added layout component in app.js routes
- toys-campaign and school-campaign routes moved out of layout.

### EVIDENCE
![1](https://user-images.githubusercontent.com/42271586/159138010-65e30a64-c338-4a14-a3a7-f1708b82c655.png)
![2](https://user-images.githubusercontent.com/42271586/159138016-e3106442-e69b-4bc7-99b7-0c742013b083.png)
